### PR TITLE
frep: fix some missing inference when debug values are part of the loop

### DIFF
--- a/llvm/lib/Target/RISCV/Snitch/SNITCHFrepLoops.cpp
+++ b/llvm/lib/Target/RISCV/Snitch/SNITCHFrepLoops.cpp
@@ -698,6 +698,11 @@ unsigned SNITCHFrepLoops::containsInvalidInstruction(MachineLoop *L, Register *I
         }
       }
 
+      if(MI->isDebugValue()) {
+        LLVM_DEBUG(dbgs() << "  ignoring debug value\n");
+        continue;
+      }
+
       skip = false;
       if(MI->isConditionalBranch()) {
         for(auto MO : MI->operands())


### PR DESCRIPTION
By ignoring `DBG_VALUE` in the frep loop for now