### PR TITLE
[RISCV] Enable the xmempool extension to be used in clang

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -74,7 +74,7 @@ static bool isSupportedExtension(StringRef Ext) {
   if (isExperimentalExtension(Ext))
     return true;
 
-  if (Ext == "xssr" || Ext == "xdma" || Ext == "xfrep")
+  if (Ext == "xssr" || Ext == "xdma" || Ext == "xfrep" || Ext == "xmempool")
     return true;
 
   // LLVM does not support "sx", "s" nor "x" extensions.


### PR DESCRIPTION
So that it can be used in `clang` using `-march=rv32imaxmempool`

CC @SamuelRiedel 