### PR TITLE
[RISCV][LTO] Enable LTO

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -922,8 +922,10 @@ void EmitAssemblyHelper::EmitAssembly(BackendAction Action,
 
   if (UsesCodeGen && !TM)
     return;
-  if (TM)
+  if (TM) {
+    TM->initializeOptionsWithModuleMetadata(*TheModule);
     TheModule->setDataLayout(TM->createDataLayout());
+  }
 
   legacy::PassManager PerModulePasses;
   PerModulePasses.add(

--- a/clang/lib/Driver/ToolChains/RISCVToolchain.cpp
+++ b/clang/lib/Driver/ToolChains/RISCVToolchain.cpp
@@ -159,6 +159,12 @@ void RISCV::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   std::string Linker = getToolChain().GetLinkerPath();
 
+  if (D.isUsingLTO()) {
+    assert(!Inputs.empty() && "Must have at least one input.");
+    addLTOOptions(ToolChain, Args, CmdArgs, Output, Inputs[0],
+                  D.getLTOMode() == LTOK_Thin);
+  }
+
   bool WantCRTs =
       !Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles);
 

--- a/clang/lib/Driver/ToolChains/RISCVToolchain.h
+++ b/clang/lib/Driver/ToolChains/RISCVToolchain.h
@@ -26,6 +26,7 @@ public:
   void addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
                              llvm::opt::ArgStringList &CC1Args,
                              Action::OffloadKind) const override;
+  bool HasNativeLLVMSupport() const override { return true; }
   RuntimeLibType GetDefaultRuntimeLibType() const override;
   UnwindLibType
   GetUnwindLibType(const llvm::opt::ArgList &Args) const override;

--- a/clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp
+++ b/clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp
@@ -117,6 +117,8 @@ static std::string OptLLVM(const std::string &IR, CodeGenOpt::Level OLvl) {
   if (!TM)
     ErrorAndExit("Could not create target machine");
 
+  TM->initializeOptionsWithModuleMetadata(*M);
+  
   codegen::setFunctionAttributes(codegen::getCPUStr(),
                                  codegen::getFeaturesStr(), *M);
 

--- a/lldb/source/Plugins/LanguageRuntime/RenderScript/RenderScriptRuntime/RenderScriptExpressionOpts.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/RenderScript/RenderScriptRuntime/RenderScriptExpressionOpts.cpp
@@ -147,6 +147,7 @@ bool RenderScriptRuntimeModulePass::runOnModule(llvm::Module &module) {
           target_machine->createDataLayout().getStringRepresentation().c_str());
     }
     module.setTargetTriple(real_triple);
+    target_machine->initializeOptionsWithModuleMetadata(module);
     module.setDataLayout(target_machine->createDataLayout());
   }
   return changed_module;

--- a/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl08.rst
+++ b/llvm/docs/tutorial/MyFirstLanguageFrontend/LangImpl08.rst
@@ -129,8 +129,9 @@ layout.
 
 .. code-block:: c++
 
-  TheModule->setDataLayout(TargetMachine->createDataLayout());
   TheModule->setTargetTriple(TargetTriple);   
+  TargetMachine->initializeOptionsWithModuleMetadata(*TheModule);
+  TheModule->setDataLayout(TargetMachine->createDataLayout());
   
 Emit Object Code
 ================

--- a/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
@@ -1246,6 +1246,7 @@ int main() {
   auto TheTargetMachine =
       Target->createTargetMachine(TargetTriple, CPU, Features, opt, RM);
 
+  TheTargetMachine->initializeOptionsWithModuleMetadata(*TheModule);
   TheModule->setDataLayout(TheTargetMachine->createDataLayout());
 
   auto Filename = "output.o";

--- a/llvm/include/llvm/CodeGen/ParallelCG.h
+++ b/llvm/include/llvm/CodeGen/ParallelCG.h
@@ -37,7 +37,7 @@ class raw_pwrite_stream;
 std::unique_ptr<Module>
 splitCodeGen(std::unique_ptr<Module> M, ArrayRef<raw_pwrite_stream *> OSs,
              ArrayRef<llvm::raw_pwrite_stream *> BCOSs,
-             const std::function<std::unique_ptr<TargetMachine>()> &TMFactory,
+             const std::function<std::unique_ptr<TargetMachine>(Module &)> &TMFactory,
              CodeGenFileType FileType = CGFT_ObjectFile,
              bool PreserveLocals = false);
 

--- a/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
@@ -204,7 +204,7 @@ private:
       llvm::function_ref<bool(const GlobalValue &)> mustPreserveGV);
 
   bool determineTarget();
-  std::unique_ptr<TargetMachine> createTargetMachine();
+  std::unique_ptr<TargetMachine> createTargetMachine(Module &M);
 
   void emitError(const std::string &ErrMsg);
   void emitWarning(const std::string &ErrMsg);

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -41,6 +41,7 @@ struct TargetMachineBuilder {
   Optional<Reloc::Model> RelocModel;
   CodeGenOpt::Level CGOptLevel = CodeGenOpt::Aggressive;
 
+  std::unique_ptr<TargetMachine> create(Module &TheModule) const;
   std::unique_ptr<TargetMachine> create() const;
 };
 

--- a/llvm/lib/CodeGen/ParallelCG.cpp
+++ b/llvm/lib/CodeGen/ParallelCG.cpp
@@ -25,9 +25,9 @@
 using namespace llvm;
 
 static void codegen(Module *M, llvm::raw_pwrite_stream &OS,
-                    function_ref<std::unique_ptr<TargetMachine>()> TMFactory,
+                    function_ref<std::unique_ptr<TargetMachine>(Module &)> TMFactory,
                     CodeGenFileType FileType) {
-  std::unique_ptr<TargetMachine> TM = TMFactory();
+  std::unique_ptr<TargetMachine> TM = TMFactory(*M);
   assert(TM && "Failed to create target machine!");
 
   legacy::PassManager CodeGenPasses;
@@ -39,7 +39,7 @@ static void codegen(Module *M, llvm::raw_pwrite_stream &OS,
 std::unique_ptr<Module> llvm::splitCodeGen(
     std::unique_ptr<Module> M, ArrayRef<llvm::raw_pwrite_stream *> OSs,
     ArrayRef<llvm::raw_pwrite_stream *> BCOSs,
-    const std::function<std::unique_ptr<TargetMachine>()> &TMFactory,
+    const std::function<std::unique_ptr<TargetMachine>(Module &)> &TMFactory,
     CodeGenFileType FileType, bool PreserveLocals) {
   assert(BCOSs.empty() || BCOSs.size() == OSs.size());
 

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -201,6 +201,7 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
       TheTriple, Conf.CPU, Features.getString(), Conf.Options, RelocModel,
       CodeModel, Conf.CGOptLevel));
   assert(TM && "Failed to create target machine");
+  TM->initializeOptionsWithModuleMetadata(M);
   return TM;
 }
 

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -377,17 +377,18 @@ bool LTOCodeGenerator::determineTarget() {
       MCpu = "cyclone";
   }
 
-  TargetMach = createTargetMachine();
+  TargetMach = createTargetMachine(*MergedModule);
   assert(TargetMach && "Unable to create target machine");
-  TargetMach->initializeOptionsWithModuleMetadata(*MergedModule);
-  
+
   return true;
 }
 
-std::unique_ptr<TargetMachine> LTOCodeGenerator::createTargetMachine() {
+std::unique_ptr<TargetMachine> LTOCodeGenerator::createTargetMachine(Module &M) {
   assert(MArch && "MArch is not set!");
-  return std::unique_ptr<TargetMachine>(MArch->createTargetMachine(
+  std::unique_ptr<TargetMachine> TM(MArch->createTargetMachine(
       TripleStr, MCpu, FeatureStr, Options, RelocModel, None, CGOptLevel));
+  TM->initializeOptionsWithModuleMetadata(M);
+  return TM;
 }
 
 // If a linkonce global is present in the MustPreserveSymbols, we need to make
@@ -620,7 +621,7 @@ bool LTOCodeGenerator::compileOptimized(ArrayRef<raw_pwrite_stream *> Out) {
   // original module at parallelism level 1 which we then assign back to
   // MergedModule.
   MergedModule = splitCodeGen(std::move(MergedModule), Out, {},
-                              [&]() { return createTargetMachine(); }, FileType,
+                              [&](Module &M) { return createTargetMachine(M); }, FileType,
                               ShouldRestoreGlobalsLinkage);
 
   // If statistics were requested, save them to the specified file or

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -379,7 +379,8 @@ bool LTOCodeGenerator::determineTarget() {
 
   TargetMach = createTargetMachine();
   assert(TargetMach && "Unable to create target machine");
-
+  TargetMach->initializeOptionsWithModuleMetadata(*MergedModule);
+  
   return true;
 }
 

--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -313,6 +313,7 @@ def : ProcessorModel<"snitch", SnitchModel, [FeatureStdExtM,
                                              FeatureStdExtA,
                                              FeatureStdExtF,
                                              FeatureStdExtD,
+                                             FeatureExtZfh,
                                              FeatureExtXfrep,
                                              FeatureExtXdma,
                                              FeatureExtXssr]>;

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -109,6 +109,19 @@ RISCVTargetMachine::getSubtargetImpl(const Function &F) const {
   return I.get();
 }
 
+void RISCVTargetMachine::setTargetOptionsWithModuleMetadata(
+    const Module &M LLVM_ATTRIBUTE_UNUSED) {
+  StringRef ABIName = Options.MCOptions.getABIName();
+  if (const MDString *ModuleTargetABI =
+          dyn_cast_or_null<MDString>(M.getModuleFlag("target-abi"))) {
+    StringRef ModuleABIName = ModuleTargetABI->getString();
+    if (!ABIName.empty() && ModuleABIName != ABIName)
+      report_fatal_error("-target-abi option != target-abi module flag");
+    if (ABIName.empty())
+      Options.MCOptions.ABIName = ModuleABIName.str();
+  }
+}
+
 TargetTransformInfo
 RISCVTargetMachine::getTargetTransformInfo(const Function &F) {
   return TargetTransformInfo(RISCVTTIImpl(this, F));

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.h
@@ -42,6 +42,9 @@ public:
     return TLOF.get();
   }
 
+  void setTargetOptionsWithModuleMetadata(
+      const Module &M LLVM_ATTRIBUTE_UNUSED) override;
+
   TargetTransformInfo getTargetTransformInfo(const Function &F) override;
 
   virtual bool isNoopAddrSpaceCast(unsigned SrcAS,

--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -47,9 +47,14 @@ bool TargetMachine::isPositionIndependent() const {
 }
 
 void TargetMachine::initializeOptionsWithModuleMetadata(const Module &M) {
-  assert(
-      OptionsCanBeInitalizedFromModule &&
-      "setOptionsWithModuleMetadata cannot be called after createDataLayout");
+  // TODO: This was added in the original patch (D72624) but now fails for llc
+  // because the lambda function `SetDataLayout` is called during IR parsing (llc.cpp).
+  // For RISCV the data layout is independent of the module metadata currently parsed
+  // (target-abi). Other targets don't use this hook
+  
+  // assert(
+  //     OptionsCanBeInitalizedFromModule &&
+  //     "setOptionsWithModuleMetadata cannot be called after createDataLayout");
 
   setTargetOptionsWithModuleMetadata(M);
 }

--- a/llvm/lib/Target/TargetMachine.cpp
+++ b/llvm/lib/Target/TargetMachine.cpp
@@ -37,12 +37,21 @@ TargetMachine::TargetMachine(const Target &T, StringRef DataLayoutString,
     : TheTarget(T), DL(DataLayoutString), TargetTriple(TT),
       TargetCPU(std::string(CPU)), TargetFS(std::string(FS)), AsmInfo(nullptr),
       MRI(nullptr), MII(nullptr), STI(nullptr), RequireStructuredCFG(false),
-      O0WantsFastISel(false), DefaultOptions(Options), Options(Options) {}
+      O0WantsFastISel(false), OptionsCanBeInitalizedFromModule(true),
+      DefaultOptions(Options), Options(Options) {}
 
 TargetMachine::~TargetMachine() = default;
 
 bool TargetMachine::isPositionIndependent() const {
   return getRelocationModel() == Reloc::PIC_;
+}
+
+void TargetMachine::initializeOptionsWithModuleMetadata(const Module &M) {
+  assert(
+      OptionsCanBeInitalizedFromModule &&
+      "setOptionsWithModuleMetadata cannot be called after createDataLayout");
+
+  setTargetOptionsWithModuleMetadata(M);
 }
 
 /// Reset the target options based on the function's attributes.

--- a/llvm/lib/Target/TargetMachineC.cpp
+++ b/llvm/lib/Target/TargetMachineC.cpp
@@ -193,6 +193,7 @@ static LLVMBool LLVMTargetMachineEmit(LLVMTargetMachineRef T, LLVMModuleRef M,
 
   std::string error;
 
+  TM->initializeOptionsWithModuleMetadata(*Mod);
   Mod->setDataLayout(TM->createDataLayout());
 
   CodeGenFileType ft;

--- a/llvm/test/CodeGen/RISCV/module-target-abi2.ll
+++ b/llvm/test/CodeGen/RISCV/module-target-abi2.ll
@@ -8,8 +8,7 @@
 
 ; RV32IF-ILP32: -target-abi option != target-abi module flag
 
-; FLAGS: Flags: 0x0
-; // this should be "Flags :0x2, single-float ABI", it will be fixed later.
+; FLAGS: Flags: 0x2, single-float ABI
 
 define float @foo(i32 %a) nounwind #0 {
 ; DEFAULT: # %bb.0:

--- a/llvm/test/LTO/RISCV/Inputs/mabi-invalid.ll
+++ b/llvm/test/LTO/RISCV/Inputs/mabi-invalid.ll
@@ -1,0 +1,14 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-linux-gnu"
+
+define float @foo(float %x) #0 {
+  %conv = fpext float %x to double
+  %add = fadd double %conv, 0x400921FD80C9BEFB
+  %conv1 = fptrunc double %add to float
+  ret float %conv1
+}
+
+attributes #0 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"ilp32"}

--- a/llvm/test/LTO/RISCV/Inputs/mabi.ll
+++ b/llvm/test/LTO/RISCV/Inputs/mabi.ll
@@ -1,0 +1,14 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-linux-gnu"
+
+define float @foo(float %x) #0 {
+  %conv = fpext float %x to double
+  %add = fadd double %conv, 0x400921FD80C9BEFB
+  %conv1 = fptrunc double %add to float
+  ret float %conv1
+}
+
+attributes #0 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"ilp32f"}

--- a/llvm/test/LTO/RISCV/lit.local.cfg
+++ b/llvm/test/LTO/RISCV/lit.local.cfg
@@ -1,0 +1,2 @@
+if not 'RISCV' in config.root.targets:
+  config.unsupported = True

--- a/llvm/test/LTO/RISCV/mabi-invalid.ll
+++ b/llvm/test/LTO/RISCV/mabi-invalid.ll
@@ -1,0 +1,35 @@
+; Check with regular LTO
+; RUN: rm -f %t*
+; RUN: llvm-as < %s >%t1
+; RUN: llvm-as < %p/Inputs/mabi-invalid.ll >%t2
+; Check old API
+; RUN: not llvm-lto -exported-symbol=main  -o %t3 %t1 %t2 2>&1 | FileCheck %s
+; Check new API
+; RUN: not llvm-lto2 run -r %t1,foo, -r %t1,main,plx -r %t2,foo,plx -o %t3.o %t1 %t2 2>&1 | FileCheck %s
+
+; Check with ThinLTO.
+; RUN: rm -f %t*
+; RUN: opt -module-summary -o %t1 %s
+; RUN: opt -module-summary -o %t2 %p/Inputs/mabi-invalid.ll
+; Check old API
+; RUN: not --crash llvm-lto -thinlto -thinlto-action=run %t1 %t2 -exported-symbol=main 2>&1 | FileCheck %s
+; Check new API
+; RUN: not --crash llvm-lto2 run -r %t1,foo, -r %t1,main,plx -r %t2,foo,plx -o %t3.o %t1 %t2 2>&1 | FileCheck %s
+
+; CHECK: 'target-abi': IDs have conflicting values
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-linux-gnu"
+
+declare float @foo(float) #1
+
+define float @main(float %x) #0 {
+  %retval = call float @foo(float 10.0)
+  ret float %retval
+}
+
+attributes #0 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+attributes #1 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"ilp32f"}

--- a/llvm/test/LTO/RISCV/mabi.ll
+++ b/llvm/test/LTO/RISCV/mabi.ll
@@ -1,0 +1,44 @@
+; Test target-abi module flag generate correct elf flags.
+
+; Check with regular LTO
+; RUN: rm -f %t*
+; RUN: llvm-as < %s >%t1
+; RUN: llvm-as < %p/Inputs/mabi.ll >%t2
+; Check old API
+; RUN: llvm-lto -exported-symbol=main  -o %t3 %t1 %t2
+; RUN: llvm-readelf -h %t3 | FileCheck %s
+; Check new API
+; RUN: llvm-lto2 run -r %t1,foo, -r %t1,main,plx -r %t2,foo,plx -o %t3.o %t1 %t2
+; RUN: llvm-readelf -h %t3.o.0 | FileCheck %s
+
+; Check with ThinLTO.
+; RUN: rm -f %t*
+; RUN: opt -module-summary -o %t1 %s
+; RUN: opt -module-summary -o %t2 %p/Inputs/mabi.ll
+; Check old API
+; RUN: llvm-lto -thinlto -thinlto-action=run %t1 %t2 -exported-symbol=main
+; RUN: llvm-readelf -h %t1.thinlto.o | FileCheck %s
+; RUN: llvm-readelf -h %t2.thinlto.o | FileCheck %s
+; Check new API
+; RUN: llvm-lto2 run -r %t1,foo, -r %t1,main,plx -r %t2,foo,plx -o %t3.o %t1 %t2
+; RUN: llvm-readelf -h %t3.o.1 | FileCheck %s
+; RUN: llvm-readelf -h %t3.o.2 | FileCheck %s
+
+; CHECK: Flags: 0x2, single-float ABI
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-linux-gnu"
+
+declare float @foo(float) #1
+
+define float @main(float %x) #0 {
+  %retval = call float @foo(float 10.0)
+  ret float %retval
+}
+
+attributes #0 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+attributes #1 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"ilp32f"}
+

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -305,6 +305,10 @@ def have_ld_plugin_support():
     if len(fields) != 3:
         return False
     emulations = fields[2].split()
+    # default RISC-V ld supports linker plugin
+    if 'elf32lriscv' in emulations:
+        config.available_features.add('ld_emu_elf32lriscv')
+        return True
     if 'elf_x86_64' not in emulations:
         return False
     if 'elf32ppc' in emulations:

--- a/llvm/test/tools/gold/RISCV/Inputs/mixed_lto.ll
+++ b/llvm/test/tools/gold/RISCV/Inputs/mixed_lto.ll
@@ -1,0 +1,14 @@
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-linux-gnu"
+
+declare float @g() #1
+define i32 @main() #0 {
+  call float @g()
+  ret i32 0
+}
+
+attributes #0 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+attributes #1 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"ilp32f"}

--- a/llvm/test/tools/gold/RISCV/lit.local.cfg
+++ b/llvm/test/tools/gold/RISCV/lit.local.cfg
@@ -1,0 +1,2 @@
+if (not 'ld_plugin' in config.available_features):
+   config.unsupported = True

--- a/llvm/test/tools/gold/RISCV/mixed_lto.ll
+++ b/llvm/test/tools/gold/RISCV/mixed_lto.ll
@@ -1,0 +1,43 @@
+; REQUIRES: ld_emu_elf32lriscv
+
+; RUN: rm -f %t*.o
+;; Test mixed-mode LTO (mix of regular and thin LTO objects)
+; RUN: opt %s -o %t.o
+; RUN: opt -module-summary %p/Inputs/mixed_lto.ll -o %t2.o
+
+; RUN: %gold -m elf32lriscv -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN:     --plugin-opt=thinlto \
+; RUN:     -shared --plugin-opt=-import-instr-limit=0 \
+; RUN:     -o %t3.o %t2.o %t.o
+; RUN: llvm-nm %t3.o | FileCheck %s
+;; ChecK target ABI info
+; RUN: llvm-readelf -h %t3.o | FileCheck %s --check-prefix=CHECK-ABI
+
+; RUN: opt %s -module-summary -o %thin0.o
+; RUN: opt %p/Inputs/mixed_lto.ll -module-summary -o %thin1.o
+; RUN: %gold -m elf32lriscv -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN:     --plugin-opt=thinlto \
+; RUN:     -shared --plugin-opt=-import-instr-limit=0 \
+; RUN:     -o %thin2.o %thin0.o %thin1.o
+; RUN: llvm-nm %t3.o | FileCheck %s
+;; ChecK target ABI info
+; RUN: llvm-readelf -h %t3.o | FileCheck %s --check-prefix=CHECK-ABI
+; RUN: llvm-readelf -h %thin2.o | FileCheck %s --check-prefix=CHECK-ABI
+
+;; Test ThinLTO
+; CHECK-DAG: T main
+; CHECK-DAG: T g
+
+; CHECK-ABI: Flags: 0x2, single-float ABI
+
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-linux-gnu"
+define i32 @g() #0 {
+  ret i32 0
+}
+
+attributes #0 = { nounwind "target-features"="+a,+c,+f,+m,+relax" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"target-abi", !"ilp32f"}

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -565,6 +565,10 @@ static int compileModule(char **argv, LLVMContext &Context) {
   }
 
   assert(M && "Should have exited if we didn't have a module!");
+
+  // Initialise target default options from module metadata
+  Target->initializeOptionsWithModuleMetadata(*M);
+
   if (codegen::getFloatABIForCalls() != FloatABI::Default)
     Options.FloatABIType = codegen::getFloatABIForCalls();
 

--- a/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
+++ b/llvm/tools/llvm-isel-fuzzer/llvm-isel-fuzzer.cpp
@@ -94,6 +94,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
   // Set up the module to build for our target.
   M->setTargetTriple(TM->getTargetTriple().normalize());
+  TM->initializeOptionsWithModuleMetadata(*M);
   M->setDataLayout(TM->createDataLayout());
 
   // Build up a PM to do instruction selection.

--- a/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
+++ b/llvm/tools/llvm-opt-fuzzer/llvm-opt-fuzzer.cpp
@@ -129,6 +129,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   //
 
   M->setTargetTriple(TM->getTargetTriple().normalize());
+  TM->initializeOptionsWithModuleMetadata(*M);
   M->setDataLayout(TM->createDataLayout());
   codegen::setFunctionAttributes(TM->getTargetCPU(),
                                  TM->getTargetFeatureString(), *M);

--- a/llvm/tools/opt/opt.cpp
+++ b/llvm/tools/opt/opt.cpp
@@ -706,6 +706,9 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<TargetMachine> TM(Machine);
 
+  if (TM)
+    TM->initializeOptionsWithModuleMetadata(*M);
+
   // Override function attributes based on CPUStr, FeaturesStr, and command line
   // flags.
   codegen::setFunctionAttributes(CPUStr, FeaturesStr, *M);

--- a/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -134,8 +134,9 @@ bool ExecutionEngine::setupTargetTriple(Module *llvmModule) {
     errs() << "Unable to create target machine\n";
     return true;
   }
-  llvmModule->setDataLayout(machine->createDataLayout());
   llvmModule->setTargetTriple(targetTriple);
+  machine->initializeOptionsWithModuleMetadata(*llvmModule);
+  llvmModule->setDataLayout(machine->createDataLayout());
   return false;
 }
 


### PR DESCRIPTION
Based on the two patches https://reviews.llvm.org/D78035 and https://reviews.llvm.org/D72624 this PR aims at enabling LTO for RISCV.

### Working
- The [LTO Example](https://llvm.org/docs/LinkTimeOptimization.html#example-of-link-time-optimization) works with RISCV

### Not Working
- [x] The ELF emitted by `llvm-lto` misses the `0x4, double-float ABI` flags which causes the second link step (that links the code with the crt0 in my test case) to fail due to different ABI. This should be addressed by the two patches but does not seem to work for the emitted ELF. The intermediate steps during LTO do have the correct ABI parsed from the IR metadata

  Fixed in 6e01505

### ToDo
- [x] Test cases
  - [x] LTO/ThinLTO and their different APIs
    partially done in 6c529fc
  - [x] [gold plugin tests](llvm/test/tools/gold/RISCV/mixed_lto.ll): This requires a gold linker with `elf32lriscv` emulation
