### PR TITLE
[CI] continue if get-changed-files fails

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
         fetch-depth: 2
     - id: files
       uses: jitterbit/get-changed-files@v1
+      continue-on-error: true
     - name: Changed C sources
       id: src_files
       run: |


### PR DESCRIPTION
The `jitterbit/get-changed-files` action fails for a lot of edge cases (e.g. rebasing, force push, ..). This change will not fail the entire action but continue on error.