### PR TITLE
[ELF] Make dot in .tbss correct and drop threadBssOffset

### DIFF
--- a/lld/ELF/LinkerScript.h
+++ b/lld/ELF/LinkerScript.h
@@ -247,7 +247,6 @@ class LinkerScript final {
   // not be used outside of the scope of a call to the above functions.
   struct AddressState {
     AddressState();
-    uint64_t threadBssOffset = 0;
     OutputSection *outSec = nullptr;
     MemoryRegion *memRegion = nullptr;
     MemoryRegion *lmaRegion = nullptr;

--- a/lld/test/ELF/linkerscript/multiple-tbss.s
+++ b/lld/test/ELF/linkerscript/multiple-tbss.s
@@ -1,4 +1,7 @@
 # REQUIRES: x86
+## Having another TLS section below a SHF_TLS SHT_NOBITS is unsupported.
+## This test just demonstrates the behavior.
+
 # RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o
 # RUN: echo "SECTIONS { }" > %t.script
 # RUN: ld.lld -T %t.script %t.o -o %t
@@ -37,7 +40,7 @@
 # CHECK-NEXT: VirtualAddress:
 # CHECK-NEXT: PhysicalAddress:
 # CHECK-NEXT: FileSize: 0
-# CHECK-NEXT: MemSize: 9
+# CHECK-NEXT: MemSize: 1
 
 .section        .tbss,"awT",@nobits
 .quad   0

--- a/lld/test/ELF/tls.s
+++ b/lld/test/ELF/tls.s
@@ -31,6 +31,10 @@ _start:
   movl %fs:c@tpoff, %eax
   movl %fs:d@tpoff, %eax
 
+/// There are more than two SHF_TLS SHT_NOBITS sections (user error).
+/// The first SHF_TLS SHT_NOBITS collides with the following SHF_TLS
+/// in addresses, so the output is not meaningful.
+/// The GNU ld output is similar.
   .global a
 	.section	.tbss,"awT",@nobits
 a:
@@ -112,7 +116,7 @@ d:
 
 // 0x2021F4 = TBSS_ADDR + 4
 
-// CHECK-NEXT:     Address: 0x2021F4
+// CHECK-NEXT:     Address: 0x2021F0
 // CHECK-NEXT:     Offset:
 // CHECK-NEXT:     Size: 4
 // CHECK-NEXT:     Link:
@@ -138,7 +142,7 @@ d:
 // CHECK-NEXT:     VirtualAddress: [[TDATA_ADDR]]
 // CHECK-NEXT:     PhysicalAddress: [[TDATA_ADDR]]
 // CHECK-NEXT:     FileSize: 8
-// CHECK-NEXT:     MemSize: 16
+// CHECK-NEXT:     MemSize: 12
 // CHECK-NEXT:     Flags [
 // CHECK-NEXT:       PF_R
 // CHECK-NEXT:     ]
@@ -165,7 +169,7 @@ d:
 // CHECK-NEXT:   }
 // CHECK-NEXT:   Symbol {
 // CHECK-NEXT:     Name: c
-// CHECK-NEXT:     Value: 0xC
+// CHECK-NEXT:     Value: 0x8
 // CHECK-NEXT:     Size:
 // CHECK-NEXT:     Binding: Global
 // CHECK-NEXT:     Type: TLS
@@ -185,7 +189,7 @@ d:
 // DIS:      Disassembly of section .text:
 // DIS-EMPTY:
 // DIS-NEXT: <_start>:
-// DIS-NEXT:   movl    %fs:-8, %eax
-// DIS-NEXT:   movl    %fs:-16, %eax
 // DIS-NEXT:   movl    %fs:-4, %eax
 // DIS-NEXT:   movl    %fs:-12, %eax
+// DIS-NEXT:   movl    %fs:-4, %eax
+// DIS-NEXT:   movl    %fs:-8, %eax


### PR DESCRIPTION
Applied the patch from here: https://reviews.llvm.org/D107208

This is required to build the snRuntime which depends on TLS.